### PR TITLE
use standard way to debug pam modules

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -260,7 +260,6 @@ void get_config(node_t *head, char *user, char *service)
   while ((getline(&line, &len, stream)) != -1) {
     if ((line[0] == '#')                     ||
         (strlen(line) < 9)                   ||
-   /*   (strncmp("DEBUG", line, 5) == 0)     || */
         (strncmp("DEFAULT", line, 7) == 0)   ||
         (strncmp("MAILSERVER", line, 10) == 0))
       continue;
@@ -306,9 +305,7 @@ void get_default(settings_t *def)
   FILE *stream;
   char *line = NULL;
   char *pch;
-/*char *debug;*/
 
-/*def->DEBUG = 0;*/
   def->MAILSERVER = NULL;
   def->DEFAULT = "CLOSE";
 
@@ -335,20 +332,6 @@ void get_default(settings_t *def)
       def->DEFAULT = strdup(pch);
       rmn(def->DEFAULT);
     }
-
-/*
-    if (strncmp("DEBUG", pch, 5) == 0) {
-      pch = strtok (NULL, ":");
-      debug = strdup(pch);
-
-      if((strncmp("True", debug, 4) == 0) ||
-         (strncmp("TRUE", debug, 4) == 0) ||
-         (strncmp("true", debug, 4) == 0))
-        def->DEBUG = 1;
-
-      free(debug);
-    }
-*/
   }
   fclose(stream);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -141,7 +141,7 @@ access_t *create_access(access_t *cur, char *flavor, node_t* conf)
     if (strncmp(conf->option, flavor, strlen(flavor)) == 0){
       if (strncmp(conf->target, "user", 4) == 0){
 
-        if (conf->param){
+        if (conf->param){ /* FIXME */
           if (cur)
             cur->next = push_access(cur, conf->param);
           else
@@ -260,7 +260,7 @@ void get_config(node_t *head, char *user, char *service)
   while ((getline(&line, &len, stream)) != -1) {
     if ((line[0] == '#')                     ||
         (strlen(line) < 9)                   ||
-        (strncmp("DEBUG", line, 5) == 0)     ||
+   /*   (strncmp("DEBUG", line, 5) == 0)     || */
         (strncmp("DEFAULT", line, 7) == 0)   ||
         (strncmp("MAILSERVER", line, 10) == 0))
       continue;
@@ -306,9 +306,9 @@ void get_default(settings_t *def)
   FILE *stream;
   char *line = NULL;
   char *pch;
-  char *debug;
+/*char *debug;*/
 
-  def->DEBUG = 0;
+/*def->DEBUG = 0;*/
   def->MAILSERVER = NULL;
   def->DEFAULT = "CLOSE";
 
@@ -336,6 +336,7 @@ void get_default(settings_t *def)
       rmn(def->DEFAULT);
     }
 
+/*
     if (strncmp("DEBUG", pch, 5) == 0) {
       pch = strtok (NULL, ":");
       debug = strdup(pch);
@@ -347,6 +348,7 @@ void get_default(settings_t *def)
 
       free(debug);
     }
+*/
   }
   fclose(stream);
 }

--- a/src/config.h
+++ b/src/config.h
@@ -32,7 +32,7 @@ typedef struct access {
 
 typedef struct settings {
     char *DEFAULT;
-    int   DEBUG;
+/*  int   DEBUG;*/
     char *MAILSERVER;
 } settings_t;
 

--- a/src/config.h
+++ b/src/config.h
@@ -32,7 +32,6 @@ typedef struct access {
 
 typedef struct settings {
     char *DEFAULT;
-/*  int   DEBUG;*/
     char *MAILSERVER;
 } settings_t;
 

--- a/src/pam2control.c
+++ b/src/pam2control.c
@@ -40,7 +40,7 @@ void       make_log_prefix(char *, char *);
 int        remove_by_service(node_t *, char *);
 access_t * create_access(access_t *, char *, node_t *);
 
-int DEBUG;
+int DEBUG = 0;
 
 void rmn(char *str)
 {

--- a/src/pam2control.c
+++ b/src/pam2control.c
@@ -87,7 +87,6 @@ int allow(pam_handle_t *pamh, char *service, char *user)
 
   if (DEBUG) {
     slog(3, "p2c: DEFAULT - '", def->DEFAULT, "'");
-/*  slog(1, "p2c: DEBUG   - 'TRUE'"); */
     slog(3, "p2c: MAILSER - '", def->MAILSERVER, "'");
   }
 

--- a/src/pam2control.c
+++ b/src/pam2control.c
@@ -84,11 +84,10 @@ int allow(pam_handle_t *pamh, char *service, char *user)
   }
 
   get_default(def);
-  DEBUG = def->DEBUG;
 
   if (DEBUG) {
     slog(3, "p2c: DEFAULT - '", def->DEFAULT, "'");
-    slog(1, "p2c: DEBUG   - 'TRUE'");
+/*  slog(1, "p2c: DEBUG   - 'TRUE'"); */
     slog(3, "p2c: MAILSER - '", def->MAILSERVER, "'");
   }
 
@@ -158,6 +157,11 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **ar
   make_log_prefix(service, user);
   slog(1, "==== authentication phase =====================");
 
+  for (int i = 0; i<argc; i++)
+  {
+    if ((argv[i]) && (strncmp(argv[i],"debug",5) == 0))
+      DEBUG = 1;
+  }
   if (strstr(host,"::1"))
     host = "localhost";
   


### PR DESCRIPTION
Now debugging could be enablen by adding `debug` word to the same line where pam2control.so is configured in the pam config file (for example, `/etc/pam.d/sshd`), not to the pam2control itself config file `/etc/pam2control/p2c.conf`.